### PR TITLE
Stage as artifact rather than branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,7 +74,6 @@ jobs:
         run: cd wasm && CARGO_HOME=../.cargo_home npm run build
 
       - name: Deploy to gh-pages
-        id: staging
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,8 @@ jobs:
       - name: Build app in release mode
         run: cd wasm && CARGO_HOME=../.cargo_home npm run build
 
-      - name: Stage on gh-pages-staging
-        id: staging
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./wasm/dist
-          publish_branch: gh-pages-staging
-          commit_message: Stage
+          name: bluepaper-staging
+          path: wasm/dist


### PR DESCRIPTION
This should resolve access restrictions for actions triggered by PRs
opened by GitHub's dependabot.